### PR TITLE
Move opaque struct definitions into own module

### DIFF
--- a/deimos/event2/_opaque_structs.d
+++ b/deimos/event2/_opaque_structs.d
@@ -1,0 +1,12 @@
+module deimos.event2._opaque_structs;
+
+struct evbuffer;
+struct evhttp_request;
+struct event_base;
+
+struct evrpc;
+struct evrpc_req_generic;
+struct evrpc_base;
+struct evrpc_request_wrapper;
+struct evrpc_status;
+struct evrpc_hook_meta;

--- a/deimos/event2/http.d
+++ b/deimos/event2/http.d
@@ -35,9 +35,10 @@ import deimos.event2.buffer;
 extern (C):
 nothrow:
 
-/* In case we haven't included the right headers yet. */
-//struct evbuffer;
-//struct event_base;
+static import deimos.event2._opaque_structs;
+
+alias evbuffer = deimos.event2._opaque_structs.evbuffer;
+alias event_base = deimos.event2._opaque_structs.event_base;
 
 /** @file event2/http.h
  *

--- a/deimos/event2/rpc.d
+++ b/deimos/event2/rpc.d
@@ -151,10 +151,12 @@ auto EVTAG_ARRAY_LEN(string member, T)(T msg) {
 }
 
 
-struct event_base;
-struct evrpc_req_generic;
-struct evrpc_request_wrapper;
-struct evrpc;
+static import deimos.event2._opaque_structs;
+
+alias event_base = deimos.event2._opaque_structs.event_base;
+alias evrpc_req_generic = deimos.event2._opaque_structs.evrpc_req_generic;
+alias evrpc_request_wrapper = deimos.event2._opaque_structs.evrpc_request_wrapper;
+alias evrpc = deimos.event2._opaque_structs.evrpc;
 
 /** The type of a specific RPC Message
  *
@@ -164,9 +166,9 @@ template EVRPC_STRUCT(string rpcname) {
 	enum EVRPC_STRUCT = "evrpc_req__" ~ rpcname;
 }
 
-struct evhttp_request;
-struct evrpc_status;
-struct evrpc_hook_meta;
+alias evhttp_request = deimos.event2._opaque_structs.evhttp_request;
+alias evrpc_status = deimos.event2._opaque_structs.evrpc_status;
+alias evrpc_hook_meta = deimos.event2._opaque_structs.evrpc_hook_meta;
 
 /** Creates the definitions and prototypes for an RPC
  *

--- a/deimos/event2/rpc_struct.d
+++ b/deimos/event2/rpc_struct.d
@@ -57,9 +57,11 @@ enum EVRPC_STATUS_ERR_HOOKABORTED = 4;
 
 /* the structure below needs to be synchronized with evrpc_req_generic */
 
-struct evbuffer;
-struct evrpc_req_generic;
-struct evrpc_base;
+static import deimos.event2._opaque_structs;
+
+alias evbuffer = deimos.event2._opaque_structs.evbuffer;
+alias evrpc_req_generic = deimos.event2._opaque_structs.evrpc_req_generic;
+alias evrpc_base = deimos.event2._opaque_structs.evrpc_base;
 
 /* Encapsulates a request */
 struct evrpc {

--- a/deimos/event2/tag.d
+++ b/deimos/event2/tag.d
@@ -40,7 +40,9 @@ nothrow:
 public import deimos.event2.util;
 import deimos.event2._d_util;
 
-struct evbuffer;
+static import deimos.event2._opaque_structs;
+
+alias evbuffer = deimos.event2._opaque_structs.evbuffer;
 
 /*
  * Marshaling tagged data - We assume that all tags are inserted in their


### PR DESCRIPTION
Multiple definitions of same opaque struct across different modules
will conflict when they are compiled together because those have different
D namespace but same mangling.